### PR TITLE
Ensure Metadata is Properly Passed to LogReturn in Logging Class

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -32,5 +32,4 @@ export const LOG_LEVEL = {
   INFO: 'info',
   VERBOSE: 'verbose',
   DEBUG: 'debug',
-  TRACE: 'trace', // New log level
 } as const;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,9 +27,10 @@ export const COLORS = {
 } as const;
 
 export const LOG_LEVEL = {
-  FATAL: "fatal",
-  ERROR: "error",
-  INFO: "info",
-  VERBOSE: "verbose",
-  DEBUG: "debug",
+  FATAL: 'fatal',
+  ERROR: 'error',
+  INFO: 'info',
+  VERBOSE: 'verbose',
+  DEBUG: 'debug',
+  TRACE: 'trace', // New log level
 } as const;

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -125,17 +125,6 @@ export class Logs {
       type: "verbose",
     });
   }
-  
-  public trace(log: string, metadata?: Metadata): LogReturn {
-  metadata = this._addDiagnosticInformation(metadata);
-  return this._log({
-    level: LOG_LEVEL.TRACE,
-    consoleLog: Logs.console.trace,
-    logMessage: log,
-    metadata,
-    type: "trace",
-  });
-  }
 
   constructor(logLevel: LogLevel) {
     this._maxLevel = this._getNumericLevel(logLevel);

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -12,6 +12,7 @@ export class Logs {
       consoleLog(logMessage, metadata);
     }
 
+    // Ensure metadata is set correctly in LogReturn
     return new LogReturn(
       {
         raw: logMessage,
@@ -19,7 +20,7 @@ export class Logs {
         type,
         level,
       },
-      metadata
+      metadata // Ensure metadata is passed correctly here
     );
   }
 
@@ -183,6 +184,7 @@ export class Logs {
         return -1;
     }
   }
+  
   static convertErrorsIntoObjects(obj: unknown): Metadata | unknown {
     // this is a utility function to render native errors in the console, the database, and on GitHub.
     if (obj instanceof Error) {
@@ -197,6 +199,7 @@ export class Logs {
         obj[key] = this.convertErrorsIntoObjects(obj[key]);
       });
     }
-    return obj;
+    
+   return obj;
   }
 }

--- a/src/logs.ts
+++ b/src/logs.ts
@@ -12,7 +12,6 @@ export class Logs {
       consoleLog(logMessage, metadata);
     }
 
-    // Ensure metadata is set correctly in LogReturn
     return new LogReturn(
       {
         raw: logMessage,
@@ -20,7 +19,7 @@ export class Logs {
         type,
         level,
       },
-      metadata // Ensure metadata is passed correctly here
+      metadata
     );
   }
 
@@ -126,6 +125,17 @@ export class Logs {
       type: "verbose",
     });
   }
+  
+  public trace(log: string, metadata?: Metadata): LogReturn {
+  metadata = this._addDiagnosticInformation(metadata);
+  return this._log({
+    level: LOG_LEVEL.TRACE,
+    consoleLog: Logs.console.trace,
+    logMessage: log,
+    metadata,
+    type: "trace",
+  });
+  }
 
   constructor(logLevel: LogLevel) {
     this._maxLevel = this._getNumericLevel(logLevel);
@@ -169,22 +179,23 @@ export class Logs {
   }
 
   private _getNumericLevel(level: LogLevel) {
-    switch (level) {
-      case LOG_LEVEL.FATAL:
-        return 0;
-      case LOG_LEVEL.ERROR:
-        return 1;
-      case LOG_LEVEL.INFO:
-        return 2;
-      case LOG_LEVEL.VERBOSE:
-        return 4;
-      case LOG_LEVEL.DEBUG:
-        return 5;
-      default:
-        return -1;
-    }
+  switch (level) {
+    case LOG_LEVEL.FATAL:
+      return 0;
+    case LOG_LEVEL.ERROR:
+      return 1;
+    case LOG_LEVEL.INFO:
+      return 2;
+    case LOG_LEVEL.VERBOSE:
+      return 4;
+    case LOG_LEVEL.DEBUG:
+      return 5;
+    case LOG_LEVEL.TRACE: // New log level
+      return 6; // Assign a higher numeric value
+    default:
+      return -1;
   }
-  
+}
   static convertErrorsIntoObjects(obj: unknown): Metadata | unknown {
     // this is a utility function to render native errors in the console, the database, and on GitHub.
     if (obj instanceof Error) {
@@ -199,7 +210,6 @@ export class Logs {
         obj[key] = this.convertErrorsIntoObjects(obj[key]);
       });
     }
-    
-   return obj;
+    return obj;
   }
 }

--- a/src/pretty-logs.ts
+++ b/src/pretty-logs.ts
@@ -9,6 +9,7 @@ export class PrettyLogs {
     this.fatal = this.fatal.bind(this);
     this.debug = this.debug.bind(this);
     this.verbose = this.verbose.bind(this);
+    this.trace = this.trace.bind(this);
   }
   public fatal(message: string, metadata?: Metadata | string | unknown) {
     this._logWithStack(LOG_LEVEL.FATAL, message, metadata);
@@ -32,6 +33,10 @@ export class PrettyLogs {
 
   public verbose(message: string, metadata?: Metadata | string) {
     this._logWithStack(LOG_LEVEL.VERBOSE, message, metadata);
+  }
+  
+  public trace(message: string, metadata?: Metadata | string) {
+    this._logWithStack(LOG_LEVEL.TRACE, message, metadata);
   }
 
   private _logWithStack(type: LogLevelWithOk, message: string, metaData?: Metadata | string | unknown) {
@@ -103,6 +108,7 @@ export class PrettyLogs {
       info: "›",
       debug: "››",
       verbose: "💬",
+      trace: "🔍",
     };
 
     const symbol = defaultSymbols[type];
@@ -128,6 +134,7 @@ export class PrettyLogs {
       info: ["info", COLORS.dim],
       debug: ["debug", COLORS.fgMagenta],
       verbose: ["debug", COLORS.dim],
+      trace: ["trace", COLORS.fgBlue],
     };
 
     const _console = console[colorMap[type][0] as keyof typeof console] as (...args: string[]) => void;

--- a/src/pretty-logs.ts
+++ b/src/pretty-logs.ts
@@ -133,7 +133,7 @@ export class PrettyLogs {
       error: ["warn", COLORS.fgYellow],
       info: ["info", COLORS.dim],
       debug: ["debug", COLORS.fgMagenta],
-      verbose: ["debug", COLORS.dim],
+      verbose: ["verbose", COLORS.dim],
       trace: ["trace", COLORS.fgBlue],
     };
 

--- a/src/pretty-logs.ts
+++ b/src/pretty-logs.ts
@@ -9,7 +9,6 @@ export class PrettyLogs {
     this.fatal = this.fatal.bind(this);
     this.debug = this.debug.bind(this);
     this.verbose = this.verbose.bind(this);
-    this.trace = this.trace.bind(this);
   }
   public fatal(message: string, metadata?: Metadata | string | unknown) {
     this._logWithStack(LOG_LEVEL.FATAL, message, metadata);
@@ -33,10 +32,6 @@ export class PrettyLogs {
 
   public verbose(message: string, metadata?: Metadata | string) {
     this._logWithStack(LOG_LEVEL.VERBOSE, message, metadata);
-  }
-  
-  public trace(message: string, metadata?: Metadata | string) {
-    this._logWithStack(LOG_LEVEL.TRACE, message, metadata);
   }
 
   private _logWithStack(type: LogLevelWithOk, message: string, metaData?: Metadata | string | unknown) {
@@ -107,8 +102,7 @@ export class PrettyLogs {
       error: "⚠",
       info: "›",
       debug: "››",
-      verbose: "💬",
-      trace: "🔍",
+      verbose: "💬"
     };
 
     const symbol = defaultSymbols[type];
@@ -133,8 +127,7 @@ export class PrettyLogs {
       error: ["warn", COLORS.fgYellow],
       info: ["info", COLORS.dim],
       debug: ["debug", COLORS.fgMagenta],
-      verbose: ["verbose", COLORS.dim],
-      trace: ["trace", COLORS.fgBlue],
+      verbose: ["verbose", COLORS.dim]
     };
 
     const _console = console[colorMap[type][0] as keyof typeof console] as (...args: string[]) => void;


### PR DESCRIPTION
This commit addresses an issue in the logging class where the metadata parameter was not consistently passed to the LogReturn instance within the _log method.

Resolves #46